### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/upstream-latest.yaml
+++ b/.github/workflows/upstream-latest.yaml
@@ -68,7 +68,7 @@ jobs:
       run: |
         sed -i'' "s/FROM apache\/superset AS/FROM apache\/superset:${{ needs.check-upstream.outputs.upstream-tag }} AS/" Dockerfile.${{ matrix.DOCKER_IMAGE }}
     - name: Publish to GitHub Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ghcr.io/${{ github.repository_owner }}/${{ matrix.DOCKER_IMAGE }}
         username: ${{ github.actor }}

--- a/.github/workflows/upstream-master.yaml
+++ b/.github/workflows/upstream-master.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Publish to GitHub Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ghcr.io/${{ github.repository_owner }}/${{ matrix.DOCKER_IMAGE }}
         username: ${{ github.actor }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore